### PR TITLE
Handle exceptions occured during cleanup step

### DIFF
--- a/ipadocker/cli.py
+++ b/ipadocker/cli.py
@@ -333,7 +333,11 @@ def run_action(ipaconfig, args, action):
         logger.error("An exception has occured when running command: %s", e)
         raise
     finally:
-        run_step(ipacontainer, 'cleanup', uid=os.getuid(), gid=os.getgid())
+        try:
+            run_step(ipacontainer, 'cleanup', uid=os.getuid(), gid=os.getgid())
+        except command.ContainerExecError:
+            logger.error("An exception has occured during cleanup: %s", e)
+
         if args.no_cleanup:
             logger.info("Container cleanup suppressed.")
             logger.info(


### PR DESCRIPTION
We do not want the cleanup step to throw unhandled excpetions and stop
the whole job. Log any errors arising from failed commands at error
level and continue operations.

https://github.com/freeipa/ipa-docker-test-runner/issues/20