### PR TITLE
Roll-back COPR repo to FreeIPA 4.6

### DIFF
--- a/data/dockerfiles/fedora/Dockerfile
+++ b/data/dockerfiles/fedora/Dockerfile
@@ -1,7 +1,7 @@
 FROM freeipa/freeipa-builder:master-latest
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 
-RUN dnf copr enable -y @freeipa/freeipa-4-7 \
+RUN dnf copr enable -y @freeipa/freeipa-4-6 \
     && dnf config-manager --set-disabled updates-testing \
     && dnf install -y freeipa-server freeipa-server-dns \
         freeipa-server-trust-ad python-ipatests --best --allowerasing \

--- a/data/dockerfiles/fedora/Dockerfile.rawhide
+++ b/data/dockerfiles/fedora/Dockerfile.rawhide
@@ -1,7 +1,7 @@
 FROM martbab/freeipa-fedora-builder:master-rawhide
 ENV container=docker LANG=en_US.utf8 LANGUAGE=en_US.utf8 LC_ALL=en_US.utf8
 
-RUN dnf copr enable -y @freeipa/freeipa-4-7 \
+RUN dnf copr enable -y @freeipa/freeipa-4-6 \
     && dnf install -y freeipa-server freeipa-server-dns \
         freeipa-server-trust-ad python-ipatests --best --allowerasing \
     && dnf clean all \


### PR DESCRIPTION
freeipa-4-7 COPR is not ready yet. This commit roll-back COPR repo to FreeIPA 4.6.
